### PR TITLE
[Fix: #144521619] Fix wrong document shown to user on startup

### DIFF
--- a/src/app/home/documents/documents.component.ts
+++ b/src/app/home/documents/documents.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+  import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { DocumentService } from './../../services/documents.service';
 import { Document } from './document';
@@ -20,8 +20,9 @@ export class DocumentComponent implements OnInit {
   }
 
   ngOnInit() {
+    const userId = localStorage.getItem('id');
     this.loading = true;
-    this.docService.getDocuments().toPromise().then((result) => {
+    this.docService.getDocuments(userId).toPromise().then((result) => {
       this.documents = result.data.map((item) => {
         item.isPublic = () => {
           return item.access === 'public';

--- a/src/app/services/documents.service.ts
+++ b/src/app/services/documents.service.ts
@@ -12,10 +12,8 @@ import { NewDocument } from './../home/documents/newDocument';
  * @return {null}
  */
 export class DocumentService {
-  userId: string;
   token: string;
   constructor(private http: Http) {
-    this.userId = localStorage.getItem('id');
     this.token = localStorage.getItem('token');
     this.getDocuments = this.getDocuments.bind(this);
   }
@@ -24,8 +22,9 @@ export class DocumentService {
    * get all user owned document
    * @return {Observable<Object>} Observable containing the response object
    */
-  getDocuments(): Observable<any> {
-    const link = `http://localhost:8080/api/users/${this.userId}/documents/`;
+  getDocuments(userId: any): Observable<any> {
+    this.token = localStorage.getItem('token');
+    const link = `http://localhost:8080/api/users/${userId}/documents/`;
     const headers = new Headers();
     headers.append('x-access-token', this.token);
     return this.http.get(link, { headers }).map(response => response.json());
@@ -53,6 +52,7 @@ export class DocumentService {
   // }
 
   createDocument(newDoc: NewDocument): Observable<any> {
+    this.token = localStorage.getItem('token');
     const link = `http://localhost:8080/api/documents/`;
     const headers = new Headers();
     headers.append('x-access-token', this.token);


### PR DESCRIPTION
#### What does this PR do?
Fix wrong document shown to user on startup
#### Action points?
* Move calling of user token in localstorage from constructor to calling method of document service
#### Pivotal tracker story (if available)
[#144521619](https://www.pivotaltracker.com/story/show/144521619)