### PR TITLE
[Feature: #142701891] Different look for private access documents

### DIFF
--- a/src/app/home/documents/documents.component.html
+++ b/src/app/home/documents/documents.component.html
@@ -26,12 +26,17 @@
         <table>
           <tbody>
             <tr>
+              <th></th>
               <th>Title</th>
               <th>Created</th>
               <th>Last Updated</th>
               <th></th>
             </tr>
-            <tr *ngFor="let document of documents">
+            <tr *ngFor="let document of documents" [class.private-doc]="!document.isPublic()">
+              <td>
+                <md-icon *ngIf="document.isPublic()" mdTooltip="Public">visibility</md-icon>
+                <md-icon *ngIf="!document.isPublic()" mdTooltip="Private">visibility_off</md-icon>
+              </td>
               <td>{{document.title}}</td>
               <td>{{document.createdAt | amDateFormat:'LL'}}</td>
               <td>{{document.updatedAt | amTimeAgo}}</td>

--- a/src/styles.css
+++ b/src/styles.css
@@ -50,3 +50,9 @@ button.call-to-action {
   border-color: #1E88E5;
   background: rgba(227,242,253,0.24);
 }
+
+.private-doc {
+  background-color: rgba(231, 76, 60, 0.3);
+  color: #fff;
+  font-weight: 400;
+}


### PR DESCRIPTION
#### What does this PR do?
Make private access documents look different from other documents
#### Action points?
* Add red background to the rows of documents with private access
#### Screenshots(if available)
<img width="1280" alt="screen shot 2017-04-28 at 6 34 54 pm" src="https://cloud.githubusercontent.com/assets/20815290/25540032/7d6e7fa2-2c41-11e7-9473-d45bec127351.png">

#### Pivotal tracker story (if available)
[#142701891](https://www.pivotaltracker.com/story/show/142701891)